### PR TITLE
Make the site MOJ-specific

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,3 @@
+title: MOJ technical guidance
+
+permalink: pretty

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,11 +1,7 @@
 <header class="header header--full-width">
   <div class="header__container">
     <div class="header__brand">
-      {% if site.service_link %}
-        <a href="{{ site.service_link }}">
-      {% else %}
-        <span>
-      {% endif %}
+        <a href="{{ site.url }}">
         {% if site.show_govuk_logo %}
           <span class="govuk-logo">
             <img class="govuk-logo__printable-crown" src="{{ "/images/gov.uk_logotype_crown_invert_trans.png" | relative_url }}" height="32" width="36">
@@ -13,16 +9,12 @@
           </span>
         {% endif %}
         <span class="header__title">
-          {{ site.service_name }}
+          {{ site.title }}
           {% if site.phase %}
             <span class="phase-banner">{{ site.phase }}</span>
           {% endif %}
         </span>
-      {% if site.service_link %}
         </a>
-      {% else %}
-        </span>
-      {% endif %}
     </div>
 
     {% if site.header_links %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,7 +9,11 @@
     {% endif %}
 
     <!-- Use title if it's in the page YAML frontmatter -->
-    <title>{{ page.title | default: "GOV.UK Documentation" }}</title>
+    {% if page.title and page.url != "/" %}
+    <title>{{ page.title }} - {{ site.title }}</title>
+    {% else %}
+    <title>{{ site.title | default: "GOV.UK Documentation" }}</title>
+    {% endif %}
 
     <!--[if gt IE 8]><!--><link href="{{ "/stylesheets/screen.css" | relative_url }}" media="screen" rel="stylesheet" ><!--<![endif]-->
     <!--[if lte IE 8]><link href="{{ "/stylesheets/screen-old-ie.css" | relative_url }}" media="screen" rel="stylesheet" ><![endif]-->

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -45,10 +45,12 @@
             <nav id="toc" class="js-toc-list toc__list" aria-labelledby="toc-heading">
               {% capture toc_markdown %}
 {{ page.content }}
+<!-- TOC-start-marker -->
 * auto-gen TOC:
 {:toc}
               {% endcapture %}
-              {{ toc_markdown | markdownify | replace: content, '' }}
+              {% assign rendered_markdown_with_toc = toc_markdown | markdownify | split: '<!-- TOC-start-marker -->' %}
+              {{ rendered_markdown_with_toc[1] }}
             </nav>
           </div>
         </div>


### PR DESCRIPTION
We should say what the site is, and remove some of GDS's more
genericised titles and URLs.

This also improves the generation of the table of contents.