### PR TITLE
Document how we store our source code

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,10 @@
 title: MOJ technical guidance
 
 permalink: pretty
+
+defaults:
+  -
+    scope:
+      path: "standards"
+    values:
+      standard: true

--- a/index.md
+++ b/index.md
@@ -7,6 +7,26 @@ has made for the products we operate.
 It complements the [Service Manual](https://www.gov.uk/service-manual),
 which covers service design more broadly.
 
+## Standards
+
+{% assign standards = site.pages
+  | where: "standard", true
+  | group_by: "category" %}
+
+{% for standard_group in standards %}
+{% if standard_group.name != "" %}
+### {{ standard_group.name }}
+{:.no_toc}
+{% else %}
+### General standards
+{:.no_toc}
+{% endif %}
+
+{% for standard in standard_group.items %}
+- [{{ standard.title }}]({{ standard.url }})
+{% endfor %}
+{% endfor %}
+
 ## Adding new guidance
 
 Create a new Markdown file that follows this pattern, add a link to it
@@ -14,6 +34,7 @@ from this page, and make a pull request:
 
 ```markdown
 ---
+category: The broader area this fits into
 expires: yyyy-mm-dd (6 months from now)
 ---
 # Thing you're writing a standard about

--- a/standards/storing-source-code.md
+++ b/standards/storing-source-code.md
@@ -1,0 +1,37 @@
+---
+expires: 2018-01-31
+---
+# Storing source code
+
+All our source code is open by default, and stored on well-known,
+public code hosting services. At the MOJ, we use GitHub.
+
+We follow the principles set out in the service manual for managing the
+code that we write:
+
+- [use version control](https://www.gov.uk/service-manual/technology/maintaining-version-control-in-coding)
+- [make source code open](https://www.gov.uk/service-manual/technology/making-source-code-open-and-reusable)
+
+You should keep secrets separate from source code, and keep them private.
+
+## GitHub
+
+New repositories for products and services live in the
+[ministryofjustice organisation](https://github.com/ministryofjustice)
+on GitHub.
+
+You can use your personal GitHub account (but you should [add your MOJ
+email address to your account](https://help.github.com/articles/adding-an-email-address-to-your-github-account/),
+and maybe [use that for notifications](https://help.github.com/articles/managing-notification-emails-for-organizations/)).
+Ask the Digital Service Desk or a member of the webops team to add you
+to the organisation. Our GitHub organisation requires that you use
+two-factor authorisation.
+
+Repositories should be clearly named, and have an appropriate licence
+and enough documentation that someone new can get started with the
+project.
+
+If the repository contains secrets rather than code, make it private
+and restrict the people who have access to it. Discuss with the
+security engineering team whether you should encrypt the contents of
+the repository.

--- a/standards/storing-source-code.md
+++ b/standards/storing-source-code.md
@@ -1,4 +1,5 @@
 ---
+category: Building software
 expires: 2018-01-31
 ---
 # Storing source code


### PR DESCRIPTION
We should document how we store source code and use GitHub.

This also adds an autogenerated list of standards to the homepage.