### PR TITLE
Fix broken links on the index page

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,7 +1,7 @@
 <header class="header header--full-width">
   <div class="header__container">
     <div class="header__brand">
-        <a href="{{ site.url }}">
+        <a href="{{ '/' | relative_url }}">
         {% if site.show_govuk_logo %}
           <span class="govuk-logo">
             <img class="govuk-logo__printable-crown" src="{{ "/images/gov.uk_logotype_crown_invert_trans.png" | relative_url }}" height="32" width="36">

--- a/index.md
+++ b/index.md
@@ -21,7 +21,7 @@ which covers service design more broadly.
 {% endif %}
 
 {% for standard in standard_group.items %}
-- [{{ standard.title }}]({{ standard.url }})
+- [{{ standard.title }}]({{ standard.url | relative_url }})
 {% endfor %}
 {% endfor %}
 


### PR DESCRIPTION
Because we're running in GitHub Pages, everything lives under `/technical-guidance/`. Most of Jekyll's URL variables are relative to the root of the Jekyll site, so we need to use the `relative_url` filter to make sure we're using the correct URL.