### PR TITLE
Add guidance for git and GitHub

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,3 +8,8 @@ defaults:
       path: "standards"
     values:
       standard: true
+  -
+    scope:
+      path: "guides"
+    values:
+      guide: true 

--- a/guides/using-git.md
+++ b/guides/using-git.md
@@ -1,0 +1,106 @@
+---
+category: Tools
+expires: 2018-05-31
+---
+# Using Git
+
+## Overview
+
+[git][git] is a [distributed version-control system][dvcs]. It's distributed,
+in that there's no central source of truth. Each copy of a repository can
+contain the entire history, and be considered an authoritative source. But we
+tend to use it in a centralised fashion, treating the version that is
+[hosted on GitHub](https://github.com/ministryofjustice) as the shared central
+version, and basing all work against that copy.
+
+It has excellent tools for branching and merging. Branching is possible in
+other version control systems, but merging can be very painful. This made
+people tentative about using that workflow.
+
+In git, that problem goes away.
+
+## Tutorials
+
+* [https://try.github.io/](https://try.github.io/)
+* [https://www.atlassian.com/git/tutorials](https://www.atlassian.com/git/tutorials)
+
+## How-to
+
+### Set up to start contributing
+
+Do not fork – [clone a repo](https://www.git-scm.com/book/en/v2/Git-Basics-Getting-a-Git-Repository#_git_cloning) from
+[https://github.com/ministryofjustice](https://github.com/ministryofjustice)
+to your local machine.
+
+### Work locally
+
+[Create a branch](https://www.git-scm.com/book/en/v2/Git-Branching-Basic-Branching-and-Merging#_basic_branching) to work in for your changes.
+
+Before you create a branch, it's worth considering the branch names and how you
+think the branch might become visible to other people.
+
+A common prefix can be useful for categorising branches, and working with tools
+for continuous integration. Naming branches such as `feature/foo`,
+`feature/bar`, and `bug/fix-column-migration` can help other people in the team
+understand whether it's a feature (new behaviour) or a fixing a bug. Having a
+common prefix can also work well with continuous integration tools such as
+[Travis][travis], which might be
+[instructed to only do certain actions on branches](https://docs.travis-ci.com/user/customizing-the-build/#Using-regular-expressions)
+named `feature/*` versus the `master` branch.
+
+Other approaches:
+
+* `feature/{JIRA-issue}-{description}` – this change is for the Jira issue
+  LM-6, and also has a human-readable description to give people more context.
+  Also, one or more people might be working on this branch (pairing, or
+  separately)
+* `jabley/thing` – this branch contains work that developer known as jabley is
+  doing. Other people might not want to rely on this branch, since it might be
+  force-pushed (but nicely please!)
+
+### Commit locally regularly
+
+This can help to get to the point where you have a working version, and then
+want to try adding a new thing. Try to aim for each [commit](https://www.git-scm.com/book/en/v2/Git-Basics-Recording-Changes-to-the-Repository)
+to be an atomic unit that delivers a non-broken version of the code-base. As
+you make more changes, consider whether it should be separate commit, or an
+amendment to the last one. You can always
+[interactively rebase your changes](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)
+to edit the commit history to a logical changeset.
+
+### Push your changes regularly
+
+This protects you from local hardware failure, and
+[ensures you don't lose your changes](https://www.git-scm.com/book/en/v2/Git-Basics-Working-with-Remotes#_pushing_remotes).
+
+### Request a review
+
+Once you have got to the point where you consider the change complete, you 
+should [open a pull request on GitHub](https://help.github.com/articles/creating-a-pull-request/),
+asking for the changes to be reviewed by someone else on the team.
+
+### Review pull requests
+
+Before commenting on a pull request, ensure you know how the person would
+prefer to get feedback. This might involve asking them first. Feedback options
+include face-to-face, pairing, via email/Slack, or commenting on a pull request.
+
+Ideally, continuous integration should be set up to provide some feedback on a
+pull request (the tests pass, coding style has been followed etc). If not,
+you'll probably want to pull the code and try it out for yourself.
+
+## Further Reading
+
+* [Anna Shipman][anna]'s description of [how to create good pull requests](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
+* [Alice Bartlett][alice] wrote
+  [a very honest account of her experience moving to coding in the open and using GitHub](http://alicebartlett.co.uk/blog/six-months-at-gds). She also did
+  [a nice talk introducing Git for non-technical folk](https://www.youtube.com/watch?v=eWxxfttcMts)
+* [Why we care about commit messages](https://github.com/alphagov/styleguides/blob/master/git.md#commit-messages).
+  Commit messages live longer than pull requests
+* [The GOV.UK pull request process has some GitHub-specific advice](https://github.com/alphagov/styleguides/blob/master/pull-requests.md)
+
+[alice]:    https://twitter.com/alicebartlett
+[anna]:     https://twitter.com/annashipman
+[dvcs]:     https://en.wikipedia.org/wiki/Distributed_version_control
+[git]:      https://git-scm.com/
+[travis]:   https://travis-ci.org/

--- a/index.md
+++ b/index.md
@@ -25,6 +25,24 @@ which covers service design more broadly.
 {% endfor %}
 {% endfor %}
 
+## Guides
+
+{% assign guides = site.pages
+  | where: "guide", true
+  | group_by: "category" %}
+
+{% for guide_group in guides %}
+{% if guide_group.name != "" %}
+### {{ guide_group.name }}
+{% else %}
+### General guides
+{% endif %}
+
+{% for guide in guide_group.items %}
+- [{{ guide.title }}]({{ guide.url | relative_url }})
+{% endfor %}
+{% endfor %}
+
 ## Adding new guidance
 
 Create a new Markdown file that follows this pattern, add a link to it
@@ -35,12 +53,12 @@ from this page, and make a pull request:
 category: The broader area this fits into
 expires: yyyy-mm-dd (6 months from now)
 ---
-# Thing you're writing a standard about
+# Thing you're writing about
 
 Introduction of a couple of paragraphs to explain why the thing you're
-writing a standard about is important. The [title should probably be a
-verb, not a noun][good-services-are-verbs] (e.g. “Storing source code”,
-not “Code repositories”).
+writing about is important. The [title should probably be a verb, not a
+noun][good-services-are-verbs] (e.g. “Storing source code”, not “Code
+repositories”).
 
 [good-services-are-verbs]: https://designnotes.blog.gov.uk/2015/06/22/good-services-are-verbs-2/
 


### PR DESCRIPTION
Not all teams in MoJ are familiar with Git. This is intended to be an
initial reference for teams to help over the learning hump. It can help
encourage conversations to get teams started with a workflow that fits
their context.