### PR TITLE
Adds MoJ Development principles

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,4 +12,9 @@ defaults:
     scope:
       path: "guides"
     values:
-      guide: true 
+      guide: true
+  -
+    scope:
+      path: "principles"
+    values:
+      principle: true

--- a/index.md
+++ b/index.md
@@ -7,6 +7,15 @@ has made for the products we operate.
 It complements the [Service Manual](https://www.gov.uk/service-manual),
 which covers service design more broadly.
 
+## Principles
+
+{% assign principle_groups = site.pages
+  | where: "principle", true %}
+
+{% for principle in principle_groups %}
+- [{{ principle.title }}]({{ principle.url | relative_url }})
+{% endfor %}
+
 ## Standards
 
 {% assign standards = site.pages

--- a/principles/development-principles.md
+++ b/principles/development-principles.md
@@ -1,0 +1,100 @@
+---
+category: Development Principles
+expires: 2019-03-31
+---
+
+# Development Principles
+
+These principles are stated in no particular order, and are *always* open to debate.
+All development is a trade-off between competing pressures, these principles are
+meant to help you decide which trade-offs are acceptable.
+
+They are guidance, not The Law - there will always be edge cases, but you should
+expect to be challenged if you go your own way.The principles are to guide future
+and current development - use your judgement, but in general only rewrite existing
+code if you really have to.
+
+
+## General Principles
+
+### 1. Share the knowledge
+
+If you have knowledge which is unique to you, it is your responsibility to share it.
+We follow “[github flow](https://guides.github.com/introduction/flow/)”, to keep branches small and short-lived, and ensure knowledge is shared.
+If you produce something reusable, package it (e.g. with pypi or rubygems) & share it with others on [MoJ Reuseables]( https://github.com/ministryofjustice/moj-reusables)
+All non-throwaway code should be reviewed - no-one is 100% right, 100% of the time… be aware that ‘throwaway’ code has a nasty habit of
+
+### 2. Code should be correct, clear, concise - in that order
+
+Correct means provably correct - with tests. All fixes & new features should include tests to prevent regressions.
+Choose clarity over cleverness - avoid monkey-patching and meta-programming unless you have a very good reason not to.
+Don’t Repeat Yourself - The ‘[Rule of Three](https://en.wikipedia.org/wiki/Rule_of_three_(computer_programming))’ is a good approach to managing duplication. Less code is usually better - but not at the expense of clarity
+
+### 3. Optimize for change
+Don’t try to solve every conceivable problem up-front, instead focus on making your code easy to change when needed
+Don’t prematurely optimize - choose clarity over performance, unless there is a serious performance issue that needs to be addressed.
+
+### 4. Something simple which exists is better than a perfect solution which doesn’t exist yet
+- We learn best from putting real things in front of real users, not trying to achieve perfection in isolation. There is no substitute for a real user clicking through a user journey in a real application. Get it done, get it in front of people, and learn early.
+
+- Don’t over-engineer. Follow the principle of Least Surprise. Choose process
+concurrency over threading & let the O/S handle it, unless there is good reason.
+When you do use threading, use language abstractions to help. Don’t roll your
+own crypto. Handle exceptions at the app level, no lower. Etc etc
+
+### 5. Everything fails, all of the time.
+Accept this and [code defensively](https://en.wikipedia.org/wiki/Defensive_programming) when calling other services.
+Every HTTP call could error or hang - handle failures appropriately and fail fast. Don’t let long-running external calls impact your user experience.
+
+### 6. Other developers are users too - treat them with respect
+If you have to explain how your code works, then your code is not clear enough.
+Comments are for explaining <strong>why</strong> something is needed, not how it works.
+Commit messages should follow [GDS guidance](https://github.com/alphagov/styleguides/blob/master/git.md)
+No-one cares how clever you are - it’s far more important to work well with your team
+APIs are interfaces too - Like any other interface, APIs need designing and iterating for usability
+Don’t pollute the global namespace
+
+### 7. Think smaller
+Stick to the Single Responsibility Principle - keep view templates, controllers and model classes as simple as possible. Keep methods short. (Concepts and patterns which may help with this: Null Object pattern, Facade pattern, Form Objects, Sandi Metz’s “[Rules for Developers](https://robots.thoughtbot.com/sandi-metz-rules-for-developers)”)
+A solution composed of many small simple things is usually better than one big complex thing.
+
+### 8. Names have power. Use them wisely.
+Don’t be cute or jokey when naming things
+Names convey meaning - well-named functions & variables can remove the need for a comment
+Avoid meaningless names like ‘obj’ / ‘result’ / ‘foo’.
+Use single-letter variables only where the letter represents a well-known mathematical property (e.g. e = mc^2), or where their meaning is otherwise clear.
+
+
+See [Naming things]({{ 'standards/naming-things' | relative_url  }})
+
+### 9. Composition over inheritance
+It’s tempting to build an inheritance tree of objects extending others and redefining methods where needed - but that often just creates tech debt for the future. Choose ‘has-a’ relationships over ‘is-a’ - e.g. a Car has-a Motor, rather than Car is-a MotorVehicle
+
+### 10. Any attempt to predict the future is likely to be wrong
+This includes estimates of work - if they are to be used for assigning budget or predicting delivery dates, they should always come with a level of confidence, or a best/worst case range (e.g. “between x and y days” or “maybe x days, but i’m only 50% confident of that”)
+The larger the chunk of work you’re estimating, the more inaccurate you will be - so if it doesn’t fit into a single sprint, break it down until it does
+
+## Ruby-specific principles:
+
+### 1. Handle exceptions at the application level, not component level
+(<i>This differs slightly from the Python principle in wording and philosophy</i>)
+
+
+Don’t swallow exceptions in your libraries, let them propagate up to the application. It’s usually only there that sufficient context exists to decide upon the appropriate action.
+Exceptions are for the unexpected & unhandleable, not flow control.
+Always put specific exception types in rescue statements (unless you have good reason not to)
+
+### 2. Use meta-programming with extreme caution
+Unless done very carefully, meta-programming makes code harder to read, debug, and understand. It also creates performance issues through purging method caches, etc. Just because you can meta-program in Ruby, doesn’t mean you should  - there’s nearly always a better way.
+
+## Python-specific principles:
+
+### 1. Handle exceptions at the application level, not component level
+(<i>This differs slightly from the related Ruby-specific principle in wording and philosophy</i>)
+
+
+Don’t swallow unexpected open type or base type exceptions in your libraries, let them propagate up to the application. It’s usually only there that sufficient context exists to decide upon the appropriate action. Always specify an exception type in a try/except unless there is a good reason not to.
+
+### 2. PEP 8
+Always try to follow [pep8 code style](https://www.python.org/dev/peps/pep-0008/) and
+consider the [Zen of Python](https://www.python.org/dev/peps/pep-0020/)

--- a/principles/frontend-development-principles.md
+++ b/principles/frontend-development-principles.md
@@ -1,0 +1,138 @@
+---
+category: Development Principles
+expires: 2019-03-31
+---
+
+# Frontend Development Principles
+
+This document lists some principles that developers at MOJ are strongly
+encouraged to follow when implementing a service’s frontend. These principles
+aren’t mandatory, but you should be able to provide a good argument if you
+choose to depart from them.
+
+These principles are in addition to [MoJ Development Principles]({{ '/standards/development-principles' | relative_url }})
+
+## 1. Follow Government Service Design Manual
+
+The most important set of recommendations you really should follow is from the [Government Service Design Manual](https://www.gov.uk/service-manual), not only because the service
+you’re designing will be assessed against it 3 times before going Live, but also
+because it covers the broad principles and is generally right. What follows are
+MOJ-specific recommendations.
+
+## 2. Make your service accessible
+Your site must be compliant with level AA of the [Web Content Accessibility Guidelines 2.0](https://www.w3.org/WAI/intro/wcag). You should also try assistive
+technology tools as much as you can. However that’ll be far from giving you a
+complete view of the issues your service might have. With a bit of luck to will
+be assessed by proper accessibility experts (like the [Digital Accessibility Centre](http://www.digitalaccessibilitycentre.org/)). But don’t wait for it to
+happen to implement accessibility principles. Another helpful thing to do is
+automatic accessibility testing as part of your continuous integration.
+
+- [pa11y](https://github.com/springernature/pa11y)
+- [Automated Accessibility Testing in Rails with capybara-accessible](https://content.pivotal.io/blog/automated-accessibility-testing-in-rails-with-capybara-accessible)
+
+
+## 3. Make it easy to change your code for copy and translation
+All the user-facing text in your application should be in the same place in the
+code, typically in templates. This includes conditional content and error
+messages. It makes this easier for a content designer to check and modify the
+application’s copy. Also make sure your service is easy to translate in another
+language.
+
+## 4. Support as many browsers as possible
+Your site is expected to work on all the browsers listed in the [Verified Browsers](https://www.gov.uk/service-manual/user-centred-design/browsers-and-devices.html#verified-browsers) page in the service manual, but try to include as many browsers as
+possible on top of that list. A browser with 0.1% market share accounts for
+50,000 visitors a month on GOV.UK. Avoid [browser sniffing](http://www.sitepoint.com/why-browser-sniffing-stinks/). Instead, use
+feature detection. That will also result in your site being forwards compatible.
+
+## 5. Use responsive design
+Make the content of your pages flow nicely with any screen size: use media
+queries, prefer relative units and use fluid grid layouts. Get some help from
+your team’s visual designer if you’re not sure what a page should look like at
+a specific resolution.
+
+## 6. Use progressive enhancement
+Design pages with the lowest common denominator of browser functionality in mind
+ (ie, HTML4, no JavaScript, no CSS), then build styling and behaviour on top.
+ Make sure that any scripting or styling you add isn’t essential to the use of
+ the service.
+
+## 7. Don’t optimise prematurely
+Optimising web pages for speed can lead to very complex code that breaks
+fundamental principles like separation of style and content. Only optimise if
+you have evidence that current front-end performance is detrimental to the use
+of the service
+
+## 8. Work with your team
+You should establish a close relationship with your team’s visual designer and
+content designer. Things can get waterfally when you expect things to happen in
+order: designer designs designs, content designer provides copy, you implement.
+That doesn’t work. Constant feedback and interactions work much more efficiently.
+
+You should make sure your designer provides multiple designs, or at least checks
+the various layouts you will implement for small screens, no JS, etc.
+
+## 9. Don’t make too many assumptions on user behaviour
+You are not the user. You can only make assumptions on how your site will be used by its intended audience. Often they’ll be wrong. If you’re not convinced, go to a user-testing session and you’ll understand. Listen to the user researcher in your team, they know more than you. Analytics also provides insight on site usage, but they don’t replace watching people use your service.
+
+## 10. Be conservative in your choice of technology
+(<i>frameworks, build tools, languages</i>)
+
+
+There are many many possible technologies, tools or libraries you may be familiar
+with, or interested in trying out. Eg, SASS, Grunt, CoffeeScript, TypeScript,
+EcmaScript 6, Polymer, etc. Keep in mind that your code should still be
+maintainable long after you’ve left. You have to be confident that the
+technology you want to use is likely to still be around a few years into the
+future: whether devs will be familiar with it or will have heard of it, whether
+documentation will still exist, and new versions are backwards compatible, etc.
+If in doubt, ask the community. jQuery, Grunt and SASS are currently widely used
+across departments and are considered OK.
+
+## 11. Beware of single-page apps
+It’s very difficult to design single-page apps (SPAs) that are accessible,
+browser-independent, offer the benefit of progressive enhancement, and are
+search-engine friendly. That’s why they’re rare in Government. Before deciding
+to implement one you need to be absolutely sure that all your users will be able
+to use the service whatever their device. Most often SPAs will be implemented
+for internal services for which the lowest-common technology is somehow high
+enough to allow them.
+
+## 12. Write unit tests
+For fine-grained inputs-results tests of your JS functions, especially ones that
+don’t have side-effects like modifying the DOM ([example from Send money to a
+prisoner](https://github.com/ministryofjustice/money-to-prisoners-send-money/blob/master/mtp_send_money/apps/send_money/tests/test_functional.py#L121)). In general there won’t be much
+“pure” JS code in your app, so there won’t be many of these.
+
+## 13. Write functional tests
+ie, tests that replicate user journeys. Cover all possible journeys, not just
+the happy path.
+- There should be many of them and they should be run every code change.
+- They should be expressed in an easy-to-read form (Eg. [Money to prisoners](https://github.com/ministryofjustice/money-to-prisoners-cashbook/blob/master/mtp_cashbook/apps/cashbook/tests/test_functional.py#L260), [Prison visits](https://github.com/ministryofjustice/prison-visits/blob/master/spec/features/unexpected_journey_spec.rb#L56))
+- You should preferably use your back-end test harness (eg, rspec, unittest) so
+that all the application’s tests are in the same place. Most support browser-based
+tests using webdriver.
+- Don’t just check the text contents of a page, but also check the computed CSS
+(eg. [Money to prisoners](https://github.com/ministryofjustice/money-to-prisoners-cashbook/blob/master/mtp_cashbook/apps/cashbook/tests/test_functional.py#L108)).
+
+
+BDD (using [cucumber](https://cucumber.io/) or any other human-readable way to
+write tests) will only work if your team has the right workflow for it. Unless
+you have someone else (ideally your product manager) committed to writing the
+tests and checking that they pass, you’ll waste time writing code to translate
+your tests into code, instead of writing it directly.
+
+
+<strong>Visual tests</strong>: automatically generating screenshots from a user journey script, and comparing with reference images. Ideal, but hard. You’ll have to regenerate your reference images every time the design changes, ideally from images supplied from your designer and not from your own implementation.
+
+## 14. Use the right tools
+When writing your code, you’ll be checking your results and debugging them in
+your favourite browser. Make sure you also check on the most common browsers.
+You may find that Firefox is best for debugging, but don’t forget to check
+Chrome and IE as often as possible. Use [browsersync](https://www.browsersync.io/)
+to try multiple browsers at once and use virtual machines for old browsers (eg. [modern.ie](https://dev.windows.com/en-us/microsoft-edge/tools/vms/))
+
+## 15. Implement SEO and semantic markup
+Apart from internal sites and ones that are on service.gov.uk (which should block
+web spiders), you should make your pages easy for robots to understand. Following
+the service standards gives you the basics of SEO, but sometimes is makes sense to
+do more, like using semantic markup so that search engines are able to find things like a court’s opening time, an address. [Schema.org](https://schema.org/) is currently gaining in popularity and is worth looking into.


### PR DESCRIPTION
I think it would be better to make our development principles more
visible for all to see and to have a clear understanding what our principles
are.

Both principles were originally set out in two separate google documents
and have not been reviewed or update for ~2years. This commit is merely
to port those two documents to this project.

I suspect that once we increase the visibility of these principles and
they have been reviewed that there will be further changes to them.