### PR TITLE
Clarify tagging guidance

### DIFF
--- a/standards/documenting-infrastructure-owners.md
+++ b/standards/documenting-infrastructure-owners.md
@@ -19,12 +19,17 @@ All of our existing cloud hosting providers support tagging ([AWS](https://docs.
 
 To ensure we can consistently search for, and report on, the tags we use, you should use the following tags. In all values, only use acronyms if you're confident that someone from another part of government would understand them.
 
+### Mandatory
+
 - `business-unit`: Should be one of `HQ`, `HMPPS`, `OPG`, `LAA`, `HMCTS`, or `CICA`. If none of these are appropriate, use an appropriate name for the area of the MOJ responsible for the service.
 - `application`: Should be the full name of the application or service (and acronym version, if commonly used), e.g. `Prison Visits Booking`, `Claim for Crown Court Defence/CCCD`.
-- `component` (optional): Which part of the system this infrastructure is for, e.g. `Staff booking interface`, `API gateway`. If there's a common name for the type of component, use that (e.g. `front-end`, `api`, `message-queue`)
 - `is-production`: `true` or `false`, to indicate if the infrastructure is part of, or supports, live production services
-- `environment-name`: The name the owners use to refer to the environment; typically something like `production`, `staging`, `test`, or `development`.
 - `owner`: The team responsible for the overall service. Should be of the form `<team-name>: <team-email>`.
+
+### Optional
+
+- `environment-name`: The name the owners use to refer to the environment; typically something like `production`, `staging`, `test`, or `development`.
+- `component`: Which part of the application this infrastructure is for, e.g. `Staff booking interface`, `API gateway`. If there's a common name for the type of component, use that (e.g. `front-end`, `api`, `message-queue`)
 - `infrastructure-support`: The team responsible for managing the infrastructure. Should be of the form `<team-name>: <team-email>`.
-- `runbook` (optional): The URL of the service's runbook.
-- `source-code` (optional): The URL(s) for any source code repositories related to this infrastructure, comma separated.
+- `runbook`: The URL of the service's runbook.
+- `source-code`: The URL(s) for any source code repositories related to this infrastructure, comma separated.

--- a/standards/documenting-infrastructure-owners.md
+++ b/standards/documenting-infrastructure-owners.md
@@ -21,7 +21,7 @@ To ensure we can consistently search for, and report on, the tags we use, you sh
 
 ### Mandatory
 
-- `business-unit`: Should be one of `HQ`, `HMPPS`, `OPG`, `LAA`, `HMCTS`, or `CICA`. If none of these are appropriate, use an appropriate name for the area of the MOJ responsible for the service.
+- `business-unit`: Should be one of `HQ`, `HMPPS`, `OPG`, `LAA`, `HMCTS`, `CICA`, or `Platforms` (for use by Platforms & Architecture team). If none of these are appropriate, use an appropriate name for the area of the MOJ responsible for the service.
 - `application`: Should be the full name of the application or service (and acronym version, if commonly used), e.g. `Prison Visits Booking`, `Claim for Crown Court Defence/CCCD`.
 - `is-production`: `true` or `false`, to indicate if the infrastructure is part of, or supports, live production services
 - `owner`: The team responsible for the overall service. Should be of the form `<team-name>: <team-email>`.


### PR DESCRIPTION
It wasn't entirely clear from the guidance which fields were absolutely
necessary and which weren't. This also adds a new `business-unit` for
centralised infrastructure under Platforms & Architecture.

Fixes #39, fixes #40.