### PR TITLE
Add standard around documenting the security vulnerability policy for MOJ domains

### DIFF
--- a/standards/document-the-security-vulnerability-policy.md
+++ b/standards/document-the-security-vulnerability-policy.md
@@ -1,0 +1,22 @@
+---
+category: Operating services
+---
+# Document the security vulnerability policy for your service
+
+All MOJ production (live) domains **must** use [security.txt](https://securitytxt.org/) in order to document the security vulnerability policy (including contact methods and so on) for your service.
+
+This includes where the domain is primarily operated by a partner (for example, commercial supplier) but the MOJ remains primarily responsible for cyber security of the domain and underlying websites or digital services.
+
+Using security.txt does not preclude you from documenting in other ways, but at minimum security.txt **must** be used.
+
+## Deploy the HTTP 301 redirect
+
+Follow the [guidance from the Cyber Security team](https://ministryofjustice.github.io/security-guidance/contact/implement-security-txt/#implementing-securitytxt).
+
+### How disclosures work
+
+When issues are reported through [cybersecurity+vulnerabilitydisclosure@digital.justice.gov.uk](mailto:cybersecurity+vulnerabilitydisclosure@digital.justice.gov.uk) they are triaged by the [Cyber Security Defensive Security Operations team](mailto:DefensiveSecurityOperationsTeam@digital.justice.gov.uk), who will then contact relevant product/service teams as required.
+
+### MOJ's disclosure policy
+
+Cyber Security maintain the [MOJ vulnerability Disclosure Policy](https://mojdigital.blog.gov.uk/vulnerability-disclosure-policy/) as well as the [central security.txt file](https://raw.githubusercontent.com/ministryofjustice/security-guidance/master/contact/vulnerability-disclosure-security.txt).


### PR DESCRIPTION
MOJ Cyber Security have published a new vuln disclosure policy (https://mojdigital.blog.gov.uk/vulnerability-disclosure-policy/) and maintain a centralised security.txt file (https://raw.githubusercontent.com/ministryofjustice/security-guidance/master/contact/vulnerability-disclosure-security.txt)

This guides the MOJ to implement a HTTP 301 redirect to the new security.txt from MOJ production (live) domains.