### PR TITLE
Fix the broken 'naming things' link in the website

### DIFF
--- a/standards/naming-domains.md
+++ b/standards/naming-domains.md
@@ -12,7 +12,7 @@ may be eligible for a `*.justice.gov.uk` domain.
 If you need to request a new domain or changes to an existing domain,
 email the [MOJ Domains team](mailto:domains@digital.justice.gov.uk),
 who will help ensure that your domain meets this standard and our
-[wider standards for naming](https://ministryofjustice.github.io/technical-guidance/standards/naming-things/#naming-things). The Domains team can also help identify which of the
+[wider standards for naming]({{ '/standards/naming-things' | relative_url }}). The Domains team can also help identify which of the
 domains below that your service is eligible to be hosted in.
 
 

--- a/standards/naming-domains.md
+++ b/standards/naming-domains.md
@@ -12,8 +12,7 @@ may be eligible for a `*.justice.gov.uk` domain.
 If you need to request a new domain or changes to an existing domain,
 email the [MOJ Domains team](mailto:domains@digital.justice.gov.uk),
 who will help ensure that your domain meets this standard and our
-[wider standards for naming]({% link standards/naming-things.md
-%}#naming-things). The Domains team can also help identify which of the
+[wider standards for naming](https://ministryofjustice.github.io/technical-guidance/standards/naming-things/#naming-things). The Domains team can also help identify which of the
 domains below that your service is eligible to be hosted in.
 
 


### PR DESCRIPTION
In the 2nd paragraph of this page:

https://ministryofjustice.github.io/technical-guidance/standards/naming-domains/#naming-domains

...there is a link to "wider standards for naming"

This link works when running the site in local development mode (i.e.
via `jekyll serve`), but doesn't work when the site is published.

This commit applies a naïve fix, by replacing the broken relative link
with a working absolute link to the live site, however this is not
ideal. We need a broader fix that makes relative links compile correctly
when the site is published.