### PR TITLE
Update default member privileges for GitHub

### DIFF
--- a/standards/storing-source-code.md
+++ b/standards/storing-source-code.md
@@ -40,4 +40,4 @@ the repository.
 
 ### Private repositories
 
-By default, any [ministryofjustice organisation](https://github.com/ministryofjustice) member can view private repositories. Unless explicitly and strictly defined on a per-repository basis to override default permissions: private repositories should be considered "organisation public" as opposed to "private" to your team/project.
+By default, any [ministryofjustice organisation](https://github.com/ministryofjustice) member has no additional privileges. This means they can clone and pull public repos only. Internal repos are essentially org-public, and anyone in the organisation can interact with them. Unless explicitly and strictly defined on a per-repository basis to override default permissions: private repositories should be considered "private" to your team/project.


### PR DESCRIPTION
We have changed the org default from `Read` to `None`. This means that
private repos are private to the team/individuals who have been granted
access.

Adding a 3rd party supplier to our organisation no longer means they
have read access to everything.

We were using git-crypt for ensuring that secrets were only readable by
the relevant teams, but a more locked-down default minimises the scope
for any accidents to leak creds etc.

'Secure by default' is a good default.