### PR TITLE
Copy typo changes from #69

### DIFF
--- a/standards/naming-domains.md
+++ b/standards/naming-domains.md
@@ -13,7 +13,7 @@ If you need to request a new domain or changes to an existing domain,
 email the [MOJ Domains team](mailto:domains@digital.justice.gov.uk),
 who will help ensure that your domain meets this standard and our
 [wider standards for naming]({{ '/standards/naming-things' | relative_url }}). The Domains team can also help identify which of the
-domains below that your service is eligible to be hosted in.
+domains below your service is eligible to be hosted in.
 
 
 ## Domain your service can have a subdomain of

--- a/standards/out-of-hours.md
+++ b/standards/out-of-hours.md
@@ -17,7 +17,7 @@ The kinds of issues that might suggest out of hours support is necessary include
 
 - Danger to someone's life
 - The MOJ's ability to provide critical, time-sensitive justice services
-- Impact to staff's and suppliers' ability to do carry out their job safely and to the best of their ability
+- Impact to staff's and suppliers' ability to carry out their job safely and to the best of their ability
 - Impairing citizens', suppliers', and partners' ability to interact with MOJ services in a way that meets their needs
 
 These and similar issues should be considered alongside your service's robustness.
@@ -34,7 +34,7 @@ Or:
 
 - You have budget to pay a third party to provide your support sustainably, and have the ability to train them sufficiently before they are expected to start supporting it.
 
-If you are unable to do either of these, you cannot support your service out of hours without risking people's health and well-being. If that is the case, you should escalate this risk and not try to provide out-of-hours support until you are in a position to do one or other of those.
+If you are unable to do either of these, you cannot support your service out of hours without risking people's health and well-being. If that is the case, you should escalate this risk and not try to provide out-of-hours support until you are in a position to do one or the other of those.
 
 It may be appropriate for a few related teams (for example, in a single service area) to share a common rota. This can allow teams that would otherwise be unable to run a rota sustainably to do so with some of their colleagues. To do this, though, you must ensure that everyone on the rota is sufficiently trained to support all of the services their rota is responsible for.
 

--- a/standards/reserving-infrastructure-capacity.md
+++ b/standards/reserving-infrastructure-capacity.md
@@ -47,7 +47,7 @@ should the need arise.
 
 ### Only reserve non-production infrastructure if it can't easily be switched off
 
-All our systems should able to scale up and down according to the
+All our systems should be able to scale up and down according to the
 demand for them at any given moment, so we're only paying for
 infrastructure when it's in active use. By extension, that means that
 all non-production infrastructure should be able to be entirely
@@ -64,7 +64,7 @@ infrastructure that can be switched off out of hours**.
 
 Non-production **infrastructure that is too difficult (or costly) to
 make able to be switched off out of hours may be considered for
-reservation** if it is expected to be required long term, .
+reservation** if it is expected to be required long term.
 
 ### Don't use reserved instances to guarantee capacity
 


### PR DESCRIPTION
I have no idea why Danger is failing on #69 - it runs fine when
I do `danger local` on my working copy.

This is an experiment to see if Danger is happier if the changes
are in a branch of this repo, rather than coming from a fork.