### PR TITLE
Remove "GOV.UK Documentation Example" from title

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: GOV.UK Documentation Example
+title: ""
 ---
 
 <%= partial 'documentation/index' %>


### PR DESCRIPTION
The title of the technical guidance site was showing up as:

```
GOV.UK Documentation Example - MOJ technical guidance
```

This change make it:

```
MOJ technical guidance
```
