### PR TITLE
Add deprecation note about dsd.io and clearer guidance about what domain you get with each hosting platform

### DIFF
--- a/source/documentation/standards/naming-domains.html.md.erb
+++ b/source/documentation/standards/naming-domains.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Naming domains
-last_reviewed_on: 2020-08-05
+last_reviewed_on: 2021-02-10
 review_in: 3 months
 ---
 
@@ -17,7 +17,6 @@ email the [MOJ Domains team](mailto:domains@digital.justice.gov.uk),
 who will help ensure that your domain meets this standard and our
 [wider standards for naming](naming-things.html). The Domains team can also help identify which of the
 domains below your service is eligible to be hosted in.
-
 
 ## Domain your service can have a subdomain of
 
@@ -42,6 +41,19 @@ Office365), or on which MOJ has a corporate presence
 (like [GitHub](https://github.com/ministryofjustice/) or
 [Trello](https://trello.com/mojds/home)) are not required to be served
 from a `*.service.justice.gov.uk` subdomain
+
+#### Cloud and Modernisation Platform subdomains
+
+If you're using the Cloud or Modernisation Platform to host your service, you will get a subdomain
+that uses the service name of the platform.
+
+**Cloud Platform**:
+
+`cloud-platform.service.justice.gov.uk`
+
+**Modernisation Platform**:
+
+`modernisation-platform.service.justice.gov.uk`
 
 ### `justice.gov.uk`
 
@@ -97,3 +109,11 @@ You should follow the above advice for these sorts of reasons:
 ![deceptive-site-alert](images/deceptive-site-alert.png)
 
 Whilst we can get Google to remove the flag, it will keep happening.
+
+## Deprecating domains within the MOJ
+
+To reduce our reliance on non `.gov.uk` domains, the following are no longer acceptable to use for new services:
+
+- `dsd.io` subdomains
+
+There is a wider drive to reduce and stop the use of these domains within MOJ.

--- a/source/documentation/standards/naming-domains.html.md.erb
+++ b/source/documentation/standards/naming-domains.html.md.erb
@@ -47,13 +47,11 @@ from a `*.service.justice.gov.uk` subdomain
 If you're using the Cloud or Modernisation Platform to host your service, you will get a subdomain
 that uses the service name of the platform.
 
-**Cloud Platform**:
+- `*.live-1.cloud-platform.service.justice.gov.uk`
+- `*.modernisation-platform.service.justice.gov.uk`
 
-`cloud-platform.service.justice.gov.uk`
-
-**Modernisation Platform**:
-
-`modernisation-platform.service.justice.gov.uk`
+These domains are not for production use, and we will work with you when your service is
+ready to go live to get a production `<application>.service(.justice).gov.uk` domain.
 
 ### `justice.gov.uk`
 
@@ -114,6 +112,8 @@ Whilst we can get Google to remove the flag, it will keep happening.
 
 To reduce our reliance on non `.gov.uk` domains, the following are no longer acceptable to use for new services:
 
-- `dsd.io` subdomains
+- `dsd.io`, which was historically used for staff services, non-production environments, and internal tools; but suffered the issues
+listed within [Pitfalls of non `.gov.uk` domains](#pitfalls-of-non-gov-uk-domains).
 
-There is a wider drive to reduce and stop the use of these domains within MOJ.
+We would also advise moving existing services off of these domains as soon as you are able as we are planning to
+decommission these domains in the near future.


### PR DESCRIPTION
- Add clearer guidance around what subdomain you get when using the Cloud or Modernisation Platform
- Add deprecation notice about no longer issuing `dsd.io` domains