### PR TITLE
Update How to host services to be more explicit about what the CP and MP is for

### DIFF
--- a/source/documentation/standards/hosting.html.md.erb
+++ b/source/documentation/standards/hosting.html.md.erb
@@ -1,64 +1,93 @@
 ---
 title: How to host services
-last_reviewed_on: 2020-09-01
+last_reviewed_on: 2021-02-17
 review_in: 3 months
 ---
 
 # <%= current_page.data.title %>
 
 At MOJ you must use the [Cloud
-Platform](https://user-guide.cloud-platform.service.justice.gov.uk/) to
-host your service unless you're advised otherwise by a member of [the
-hosting team](https://peoplefinder.service.gov.uk/teams/hosting). Your
-team can get started on the Cloud Platform without letting anyone know;
-just follow [the Cloud Platform documentation](https://user-guide.cloud-platform.service.justice.gov.uk/) and
-get in touch with the Cloud Platform team if you need help.
+Platform](https://user-guide.cloud-platform.service.justice.gov.uk/)
+to host your service by default, unless you're advised otherwise by a
+member of the [hosting
+team](https://peoplefinder.service.gov.uk/teams/hosting). This includes
+applications that would otherwise sit in your own infrastructure if
+you have it.
+
+If your team needs to host legacy services, you should plan to use the
+[Modernisation
+Platform](https://ministryofjustice.github.io/modernisation-platform/user-guide).
+
+## Cloud Platform
 
 The Cloud Platform is a modern hosting platform for digital services:
 
 - It makes it quick and easy to 'just deploy an app'
 - Teams get the features they need to operate their service, such as
-  easy scalability, zero downtime deploys, security scanning,
-  monitoring, logging, and more, all setup for you by default
+  easy scalability, zero downtime deploys, security scanning, monitoring,
+  logging, and more, all setup for you by default
 - When you need the full power of AWS or Kubernetes, it's all available
 - Configuration is all self-service, using Infrastructure as Code with
   managed CI/CD and GitOps processes
 - The Cloud Platform team manage the hosting and provide support for
   the platform
+- You can host [GOV.UK Prototype Kit sites](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/prototype-kit.html#create-a-gov-uk-prototype-kit-site)
+  quickly and easily
 
-If you think that your service might require other hosting, [get in
-touch with the hosting
-team](mailto:hosting-leads@digital.justice.gov.uk) and we'll help
-identify which of our other hosting options is best for your service,
-or set up extra accounts if we've already identified the right
-setup for you:
+Your team can get started on the Cloud Platform without letting anyone
+know; just follow the [Cloud Platform
+documentation](https://user-guide.cloud-platform.service.justice.gov.uk/#cloud-platform-user-guide)
+and get in touch with the Cloud Platform team if you need help.
 
-- AWS Modernisation Platform (currently in development; [get in touch
-  with the team](mailto:modernisation-platform@digital.justice.gov.uk)
-  if you'd like to learn more)
+## Modernisation Platform
+
+The Modernisation Platform is a cloud-first hosting platform for
+legacy applications. It's currently in development, and you can become
+an early adopter by following the [Modernisation Platform user
+guide](https://ministryofjustice.github.io/modernisation-platform/user-guide).
+
+- It will make it easy to create non-Kubernetes environments for applications
+- It will align with the MOJ [Security Guidance](https://ministryofjustice.github.io/security-guidance/baseline-aws-accounts/#baseline-for-amazon-web-services-accounts)
+- It will standardise commonalities across applications, such as: application networking, certificate management, CI/CD processes; with infrastructure as code
+- It will support you modernising your applications
+
+## Other hosting infrastructure
+
+If you think your service might require other hosting, [get in touch
+with the hosting team](mailto:hosting-leads@digital.justice.gov.uk)
+and we'll help identify which of our other hosting options is best for
+your service, or set up extra accounts if we've already identified the
+right setup for you. This includes:
+
 - LAA AWS and 6Degrees infrastructure
 - HMPPS Azure infrastructure
 - Self-managed AWS infrastructure
 - Retirement infrastructure
 
+If you self-manage your own AWS infrastructure, you should consider
+moving it to the [Cloud Platform](#cloud-platform) or the
+[Modernisation Platform](#modernisation-platform).
+
 ## We use public cloud hosting by default
 
 We follow the [Government Cloud First
 policy](https://www.gov.uk/guidance/government-cloud-first-policy) and
-use public cloud Platform as a Service (PaaS) and Infrastructure as a
-Service (IaaS) infrastructure to host our services.
+use public cloud "Platform as a Service" (PaaS) and "Infrastructure as
+a Service" (IaaS) infrastructure to host our services.
 
-Our choice of cloud platforms:
+Our choice of platforms:
 
 - are highly scalable and available to meet the needs of service users
-- have automated tools for MOJ administrators to manage their
-  environments
+- have automated tools for MOJ administrators to manage their environments
+- standardise infrastructure across MOJ
+- help reduce cost across MOJ
+- support building capability across the department rather than in silos
 
 We currently use [Amazon Web Services (AWS)](https://aws.amazon.com/)
-by default for scalable computing, storage and deployment services, but
-we may recommend some services are hosted in [Microsoft
-Azure](https://azure.microsoft.com/), based on the needs of the service
-and its relationship to other services already in Azure.
+by default for scalable computing, storage and deployment services,
+but we may recommend some services are hosted in [Microsoft
+Azure](https://azure.microsoft.com/), based on the needs of the
+service and its relationship to other services already in Azure.
 
 If your service is currently hosted outside of AWS or Azure, get in
 touch with [the Application Modernisation team](#TODO) to plan for its
@@ -66,14 +95,18 @@ future hosting.
 
 ## We pay for hosting centrally by default
 
-By default, we pay for all use of AWS and Azure services (and some
-others) across MOJ (excluding HMCTS) centrally. As part of this, the
-hosting team will routinely review your use of hosting to ensure you're
-using infrastructure appropriately, keeping it secure, keeping it up to
-date, and making the best use of the money you're spending.
+By default, we pay for all use of AWS and Azure services across MOJ
+(excluding HMCTS) centrally.
 
-If your service or services cost more than £30,000 per year to host, we
-may need to cross-charge you for your use. In this case, we will still
-work with you to ensure you're using your infrastructure appropriately
-and safely. This typically only applies to very large services or
-teams, and we only currently cross-charge two groups.
+As part of this, the hosting team will routinely review your use of
+hosting to ensure you're using infrastructure appropriately, keeping
+it secure and up to date, and making the best use of the money you're
+spending.
+
+If your service or services cost more than £30,000 per year to host,
+we may need to cross-charge you for your use. Cross-charging typically
+only applies to very large services or teams, and we currently only
+cross-charge two groups.
+
+If you we do need to cross-charge you, we will still work with you to
+ensure you're using infrastructure appropriately and safely.

--- a/source/documentation/standards/hosting.html.md.erb
+++ b/source/documentation/standards/hosting.html.md.erb
@@ -25,7 +25,7 @@ The Cloud Platform is a modern hosting platform for digital services:
 - It makes it quick and easy to 'just deploy an app'
 - Teams get the features they need to operate their service, such as
   easy scalability, zero downtime deploys, security scanning, monitoring,
-  logging, and more, all setup for you by default
+  logging, and more, all set up for you by default
 - When you need the full power of AWS or Kubernetes, it's all available
 - Configuration is all self-service, using Infrastructure as Code with
   managed CI/CD and GitOps processes


### PR DESCRIPTION
>TLDR: This PR aims to make it clearer about the expectations of teams to use the Cloud Platform or Modernisation Platform and explicitly defines what cross-charging means for service users.

- Make it more explicit that teams should use the Cloud Platform, even if the application would normally sit within their own infrastructure
- Makes it clearer as to expectations of using the Cloud Platform or Modernisation Platform
- Encourages teams to plan to use the Modernisation Platform for legacy services
- Includes the Cloud Platform offering of hosting [GOV.UK Prototype Kit prototypes](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/prototype-kit.html#create-a-gov-uk-prototype-kit-site)
- Encourages teams who self-manage their own infrastructure to consider using internal offerings
- Describes the Modernisation Platform offering in a bit more detail
- Rewords and adds benefits to using public cloud hosting and what it means for MOJ
- Explicitly defines what cross-charging means and makes it clearer that MOJ Hosting will still support the appropriate and safe use of infrastructure provisioned