### PR TITLE
Fix grammar on How to host services

### DIFF
--- a/source/documentation/standards/hosting.html.md.erb
+++ b/source/documentation/standards/hosting.html.md.erb
@@ -108,5 +108,5 @@ we may need to cross-charge you for your use. Cross-charging typically
 only applies to very large services or teams, and we currently only
 cross-charge two groups.
 
-If you we do need to cross-charge you, we will still work with you to
+If we do need to cross-charge you, we will still work with you to
 ensure you're using infrastructure appropriately and safely.


### PR DESCRIPTION
Removes an extraneous word (“you”).