### PR TITLE
Updated way to be added to our GitHub org

### DIFF
--- a/source/documentation/standards/out-of-hours.html.md.erb
+++ b/source/documentation/standards/out-of-hours.html.md.erb
@@ -60,7 +60,7 @@ To avoid that, a few core criteria must be met:
 
 ### Contacting people on call about an issue
 
-To allow people to manage how they are contacted when on call, the MOJ uses [PagerDuty](https://www.pagerduty.com). PagerDuty (and systems like it) allows people on call to specify how they prefer to be contacted (in-app notifications, phone calls, text messages) and when, relative to an incident being raised. It also ensures that the people on call are paged according to pre-defined escalation policies (primary first, then secondary, then repeat).
+To allow people to manage how they are contacted when on call, the MOJ uses <a href="https://www.pagerduty.com" data-proofer-ignore>PagerDuty</a>. PagerDuty (and systems like it) allows people on call to specify how they prefer to be contacted (in-app notifications, phone calls, text messages) and when, relative to an incident being raised. It also ensures that the people on call are paged according to pre-defined escalation policies (primary first, then secondary, then repeat).
 
 People on call should *never* be contacted directly to report issues, especially not through their personal phone number. Contacting individuals directly creates a dependency on them, making them implicitly on call 100% of the time. This is not good for individuals' mental health, and can result in them withdrawing entirely from support or even leaving the organisation, meaning we entirely lose their knowledge and skill at supporting the system, rather than allowing others to learn from it and them to work at a sustainable level.
 

--- a/source/documentation/standards/storing-source-code.html.md.erb
+++ b/source/documentation/standards/storing-source-code.html.md.erb
@@ -70,9 +70,10 @@ exposed to GitHub organisation admins, aside from what is already public.
 You don't have to use your real name or photo - just let your colleagues know
 your username.
 
-Ask the Digital Service Desk or a member of the webops team to add you
-to the MOJ organisation. Our GitHub organisation requires that you use two-factor authorisation.
-
+To be added to the `ministryofjustice` organisation, first ensure you've enabled two-factor authentication.
+Then make a request on ServiceNow:
+[GitHub for D&T staff - Add/Remove](https://mojprod.service-now.com/moj_sp?id=sc_cat_item&sys_id=5beac6f7dbdc609050fbbfce3b96191f)
+(or ask a member of the webops team).
 
 [template repository]: https://github.com/ministryofjustice/template-repository
 [github actions]: https://github.com/ministryofjustice/github-actions


### PR DESCRIPTION
Following advice from DSD: https://mojdt.slack.com/archives/C59CX1RHN/p1627395081354600

And added 'data-proofer-ignore' to link, because in the CI checks, html-proofer complains about 403s. PagerDuty has CloudFlare settings that don't like bots like this link checker.