### PR TITLE
Add CNAME to docs output

### DIFF
--- a/source/CNAME
+++ b/source/CNAME
@@ -1,0 +1,1 @@
+technical-guidance.service.justice.gov.uk


### PR DESCRIPTION
Adds a CNAME to source to be output in the `docs/` directory. This is [required as we use a site generator to publish](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/troubleshooting-custom-domains-and-github-pages#cname-errors) this site.