### PR TITLE
Bring ministryofjustice/tech-docs-github-pages-publisher versions inline with each other

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -10,7 +10,7 @@ jobs:
   check_links:
     runs-on: ubuntu-latest
     container:
-      image: ministryofjustice/tech-docs-github-pages-publisher:1.5
+      image: ministryofjustice/tech-docs-github-pages-publisher:1.4
     steps:
     - uses: actions/checkout@v3
     - name: htmlproofer

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
   run:
     runs-on: ubuntu-latest
     container:
-      image: ministryofjustice/tech-docs-github-pages-publisher:1.5
+      image: ministryofjustice/tech-docs-github-pages-publisher:1.4
     steps:
     - uses: actions/checkout@v3
     - name: Publish

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-IMAGE := ministryofjustice/tech-docs-github-pages-publisher:1.3
+IMAGE := ministryofjustice/tech-docs-github-pages-publisher:1.4
 
 # Use this to run a local instance of the documentation site, while editing
 .PHONY: preview


### PR DESCRIPTION
This PR brings parity to the version of `tech-docs-github-pages-publisher` that is used within GitHub workflows and the `makefile` to ensure local previews and deployed publishes utilise the same version.

The last working version of `tech-docs-github-pages-publisher` is v1.4. See #150 for details.

Workflows have been failing since #148.