### PR TITLE
Explicitly require services to use our hosting

### DIFF
--- a/source/documentation/standards/hosting.html.md.erb
+++ b/source/documentation/standards/hosting.html.md.erb
@@ -8,15 +8,19 @@ review_in: 3 months
 # <%= current_page.data.title %>
 
 At MOJ you must use the [Cloud Platform]
-(https://user-guide.cloud-platform.service.justice.gov.uk/) to host your
-service by default, unless you're advised otherwise by a member of the
-[hosting team](https://peoplefinder.service.gov.uk/teams/hosting). This
-includes applications that would otherwise sit in your own infrastructure if
-you have it.
+(https://user-guide.cloud-platform.service.justice.gov.uk/) to host
+your service by default, unless you're advised otherwise by a member of
+the [hosting team](https://peoplefinder.service.gov.uk/teams/hosting).
+This includes applications that would otherwise sit in your own, or
+your supplier's, infrastructure, regardless of who manages it. If you
+would like to discuss this with the hosting team, please [get in
+touch](mailto:hosting-leads@digital.justice.gov.uk).
 
-If your team needs to host legacy services, you should plan to use the
+If your team needs to host legacy services, you must use the
 [Modernisation Platform]
-(https://user-guide.modernisation-platform.service.justice.gov.uk/#modernisation-platform).
+(https://user-guide.modernisation-platform.service.justice.gov.uk/). If
+you have an existing legacy service, you should plan to migrate it to
+the Modernisation Platform as soon as you're able.
 
 ## Cloud Platform
 


### PR DESCRIPTION
We've received some feedback that it's not clear (particularly to suppliers) that they should be hosting services using our platforms. This attempts to address that, and also provides an externally-useful email address to get more information.