### PR TITLE
Update GDS link commits link

### DIFF
--- a/source/documentation/guides/using-git.html.md.erb
+++ b/source/documentation/guides/using-git.html.md.erb
@@ -100,7 +100,7 @@ you'll probably want to pull the code and try it out for yourself.
   [a nice talk introducing Git for non-technical folk](https://www.youtube.com/watch?v=eWxxfttcMts)
 * [Why we care about commit messages](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#commit-messages).
   Commit messages live longer than pull requests
-* [The GOV.UK pull request process has some GitHub-specific advice](https://github.com/alphagov/styleguides/blob/master/pull-requests.md)
+* [The GOV.UK pull request process has some GitHub-specific advice](https://gds-way.cloudapps.digital/standards/pull-requests.html)
 
 [alice]:    https://twitter.com/alicebartlett
 [anna]:     https://twitter.com/annashipman

--- a/source/documentation/guides/using-git.html.md.erb
+++ b/source/documentation/guides/using-git.html.md.erb
@@ -98,7 +98,7 @@ you'll probably want to pull the code and try it out for yourself.
 * [Alice Bartlett][alice] wrote
   [a very honest account of her experience moving to coding in the open and using GitHub](https://alicebartlett.co.uk/blog/six-months-at-gds). She also did
   [a nice talk introducing Git for non-technical folk](https://www.youtube.com/watch?v=eWxxfttcMts)
-* [Why we care about commit messages](https://github.com/alphagov/styleguides/blob/master/git.md#commit-messages).
+* [Why we care about commit messages](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#commit-messages).
   Commit messages live longer than pull requests
 * [The GOV.UK pull request process has some GitHub-specific advice](https://github.com/alphagov/styleguides/blob/master/pull-requests.md)
 


### PR DESCRIPTION
https://github.com/alphagov/styleguides is archived and points to https://gds-way.cloudapps.digital as the replacement.