### PR TITLE
Clarify restrictions on other hosting options

### DIFF
--- a/source/documentation/standards/hosting.html.md.erb
+++ b/source/documentation/standards/hosting.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#operations-engineering-alerts"
 title: How to host services
-last_reviewed_on: 2023-02-24
+last_reviewed_on: 2023-03-21
 review_in: 3 months
 ---
 
@@ -61,20 +61,14 @@ adopter by following the [Modernisation Platform user guide]
 
 ## Other hosting infrastructure
 
-If you think your service might require other hosting, whether in AWS, Azure, or
-anything else, [get in touch with the hosting team]
-(mailto:hosting-leads@digital.justice.gov.uk) and we'll help identify which of
-our other hosting options is best for your service, or set up extra accounts if
-we've already identified the right setup for you. This includes:
+You should not use other hosting platforms to host MOJ services, or run
+your own infrastructure outside of these platforms.
 
-- LAA AWS and 6Degrees infrastructure
-- HMPPS Azure infrastructure
-- Self-managed infrastructure, in AWS or Azure
-- Retirement infrastructure
-
-If you self-manage your own infrastructure, you should consider moving it to
-the [Cloud Platform](#cloud-platform) or the [Modernisation Platform]
-(#modernisation-platform).
+If you currently use other infrastructure to hosting your service, you
+should move it to the [Cloud Platform](#cloud-platform) or
+the [Modernisation Platform](#modernisation-platform).
+[Get in touch](mailto:hosting-leads@digital.justice.gov.uk) with us if
+you'd like support migrating to one of these platforms.
 
 ### Hosting static websites or documentation
 


### PR DESCRIPTION
Services aren't allowed to use other hosting options, so we should make that more explicit to avoid being asked about it.