### PR TITLE
Update tech-docs-github-pages-publisher to v3.0.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: ministryofjustice/tech-docs-github-pages-publisher:v3
+      image: ministryofjustice/tech-docs-github-pages-publisher:v3.0.1
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
👀 Purpose
To use new version of tech-docs-github-pages-publisher

♻️ What's changed
Updated to v3.0.1