### PR TITLE
update github guidance

### DIFF
--- a/source/documentation/standards/storing-source-code.html.md.erb
+++ b/source/documentation/standards/storing-source-code.html.md.erb
@@ -85,7 +85,7 @@ your username.
 
 Being a **member** of the MoJ organisation is for staff who are permanent employees or contractors working directly with the MoJ.
 To be added to the `ministryofjustice` organisation, first ensure you've enabled two-factor authentication.
-If you have a `@digital.justice.gov.uk` or `@justice.gov.uk` email address and only require access to the `ministryofjustice` Organisation, you can simply join via [SSO](https://github.com/orgs/ministryofjustice/sso) to join.
+If you have a `@digital.justice.gov.uk` or `@justice.gov.uk` email address and only require access to the `ministryofjustice` Organisation, you can simply join via [SSO](https://github.com/orgs/ministryofjustice/sso).
 For more information, please refer to the [Operations Engineering user guide](https://user-guide.operations-engineering.service.justice.gov.uk/documentation/information/mojgithubenterprise.html).
 
 #### Outside Collaborator

--- a/source/documentation/standards/storing-source-code.html.md.erb
+++ b/source/documentation/standards/storing-source-code.html.md.erb
@@ -85,7 +85,8 @@ your username.
 
 Being a **member** of the MoJ organisation is for staff who are permanent employees or contractors working directly with the MoJ.
 To be added to the `ministryofjustice` organisation, first ensure you've enabled two-factor authentication.
-Then make a request to the operations-engineering team to be added / removed via [email](mailto:operations-engineering@digital.justice.gov.uk) or the [#ask-operations-engineering](https://mojdt.slack.com/archives/C01BUKJSZD4).
+If you have a `@digital.justice.gov.uk` or `@justice.gov.uk` email address and only require access to the `ministryofjustice` Organisation, you can simply join via [SSO](https://github.com/orgs/ministryofjustice/sso) to join.
+For more information, please refer to the [Operations Engineering user guide](https://user-guide.operations-engineering.service.justice.gov.uk/documentation/information/mojgithubenterprise.html).
 
 #### Outside Collaborator
 


### PR DESCRIPTION
Update GitHub guidance to join ministryofjustice organisation to account for new SSO process which uses SSO link, for Google and Microsoft accounts.