### PR TITLE
Remove Security Guide links from tech guide

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#operations-engineering-alerts"
 title: MOJ technical guidance
-last_reviewed_on: 2024-11-28
+last_reviewed_on: 2024-12-05
 review_in: 3 months
 ---
 
@@ -13,8 +13,6 @@ This site documents some of the technical decisions that the
 
 It complements the [Service Manual](https://www.gov.uk/service-manual),
 which covers service design more broadly.
-
-[Security guidance](https://ministryofjustice.github.io/security-guidance/) is an accompanying source of security-specific guidance.
 
 ## Principles
 
@@ -50,10 +48,6 @@ which covers service design more broadly.
 ### Tools
 
 * [Using Git](documentation/guides/using-git.html)
-
-## Security Guidance
-
-The [security guidance](https://ministryofjustice.github.io/security-guidance/) should be read together with this technical guidance.
 
 ## Adding new guidance
 


### PR DESCRIPTION
This PR remove the link to the Security Guide. There are other better way that the Security Guidance is sign-posted.