### PR TITLE
Add service-area tag

### DIFF
--- a/source/documentation/standards/documenting-infrastructure-owners.html.md.erb
+++ b/source/documentation/standards/documenting-infrastructure-owners.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#operations-engineering-alerts"
 title: Documenting owners of infrastructure
-last_reviewed_on: 2024-10-23
+last_reviewed_on: 2025-02-04
 review_in: 3 months
 ---
 
@@ -25,7 +25,8 @@ To ensure we can consistently search for, and report on, the tags we use, you sh
 
 ### Mandatory
 
-- `business-unit`: Should be one of `HQ`, `HMPPS`, `OPG`, `LAA`, `HMCTS`, `CICA`, or `Platforms` (for use by Platforms & Architecture team). If none of these are appropriate, use an appropriate name for the area of the MOJ responsible for the service.
+- `business-unit`: Should be one of `HQ`, `HMPPS`, `OPG`, `LAA`, `HMCTS`, `CICA`, or `Platforms` (for use by Platforms & Architecture team). If none of these are appropriate, please contact us via `#ask-operations-engineering` Slack channel or submit a pull-request against the [policy managed in code](https://github.com/ministryofjustice/aws-root-account/blob/main/management-account/terraform/organizations-policy-tags.tf).
+- `service-area` : Should be the full name of the Service Area in which your team is based e.g. `Education Skills & Work`, `Manage a Workforce`, `Hosting`.
 - `application`: Should be the full name of the application or service (and acronym version, if commonly used), e.g. `Prison Visits Booking`, `Claim for Crown Court Defence/CCCD`.
 - `is-production`: `true` or `false`, to indicate if the infrastructure is part of, or supports, live production services
 - `owner`: Should be of the form `<team-name>: <team-email>`. This is the team responsible for the overall service.


### PR DESCRIPTION
## 👀 Purpose

- This PR updates the tagging policy to incorporate changes to policy around `business-unit`, and the addition of a `service-area` tag

## ♻️ What's changed

- Update `business-unit` tag policy
- Add `service-area` tag